### PR TITLE
Add ability to supply parameters to notebook

### DIFF
--- a/notebook_executor.sh
+++ b/notebook_executor.sh
@@ -13,11 +13,18 @@ OUTPUT_NOTEBOOK_PATH="${NOTEBOOKS_FOLDER}/${OUTPUT_NOTEBOOK_NAME}"
 
 INPUT_NOTEBOOK_GCS_FILE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/input_notebook -H "Metadata-Flavor: Google")
 OUTPUT_NOTEBOOK_GCS_FOLDER=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/output_notebook -H "Metadata-Flavor: Google")
+PARAMETERS_GCS_FILE=$(curl http://metadata.google.internal/computeMetadata/v1/instance/attributes/parameters_file -H "Metadata-Flavor: Google")
 
 gsutil cp "${INPUT_NOTEBOOK_GCS_FILE}" "${NOTEBOOKS_FOLDER}/"
 INPUT_NOTEBOOK_PATH=`find ${NOTEBOOKS_FOLDER}/ | grep ipynb`
 
-papermill "${INPUT_NOTEBOOK_PATH}" "${OUTPUT_NOTEBOOK_PATH}"
+if [-z "$PARAMETERS_GCS_FILE"]
+then
+  papermill "${INPUT_NOTEBOOK_PATH}" "${OUTPUT_NOTEBOOK_PATH}"
+else
+  gsutil cp $PARAMETERS_GCS_FILE params.yaml
+  papermill "${INPUT_NOTEBOOK_PATH}" "${OUTPUT_NOTEBOOK_PATH}" -f params.yaml
+fi
 
 gsutil cp "${OUTPUT_NOTEBOOK_PATH}" "${OUTPUT_NOTEBOOK_GCS_FOLDER}"
 

--- a/notebook_executor.sh
+++ b/notebook_executor.sh
@@ -22,7 +22,7 @@ if [-z "$PARAMETERS_GCS_FILE"]
 then
   papermill "${INPUT_NOTEBOOK_PATH}" "${OUTPUT_NOTEBOOK_PATH}"
 else
-  gsutil cp $PARAMETERS_GCS_FILE params.yaml
+  gsutil cp "${PARAMETERS_GCS_FILE}" params.yaml
   papermill "${INPUT_NOTEBOOK_PATH}" "${OUTPUT_NOTEBOOK_PATH}" -f params.yaml
 fi
 


### PR DESCRIPTION
Specify a YAML file on GCS -- these parameters will replace a cell tagged 'parameters' as explained in papermill documentation.  For example

```
%%writefile params.yaml
---
DEVELOP_MODE: True
```

```
gsutil cp mynotebook.ipynb params.yaml gs://$BUCKET/flights/notebook
```

```
metadata="parameters_file=$PARAMS,input_notebook=$INPUT_NOTEBOOK,output_notebook=$OUTPUT_NOTEBOOK_DIR,startup-script-url=$LAUNCHER_SCRIPT"
```